### PR TITLE
Add useUTC functionality

### DIFF
--- a/mssql.html
+++ b/mssql.html
@@ -40,9 +40,14 @@
         <input type="text" id="node-config-input-database">
     </div>
     <div class="form-row">
-        <label for="node-config-input-encyption"><i class="fa fa-user"></i> Use Encryption?</label>
-        <input type="checkbox" id="node-config-input-encyption">
+        <label for="node-config-input-encryption"><i class="fa fa-user"></i> Use Encryption?</label>
+        <input type="checkbox" id="node-config-input-encryption">
         <div class="form-tips">SQL Databases hosted on Azure will need this checked</div>
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-useUTC"><i class="fa fa-clock-o"></i> Assume UTC?</label>
+        <input type="checkbox" id="node-config-input-useUTC">
+        <div class="form-tips">Times will be assumed to be UTC by default.</div>
     </div>
 </script>
 
@@ -52,16 +57,18 @@
         defaults: {
             name: {value:""},
             server: {value:""},
-            encyption:{value:true},
-            database: {value:""}
+            encryption: {value:true},
+            database: {value:""},
+            useUTC: {value:true}
         },
         inputs:0,
         outputs:0,
         credentials: {
             username: {type:"text"},
             password: {type:"password"},
-            domain: {type:"text"}
+            domain: {type:"text"},
         },
+
         label: function() {
             return this.name || "MSSQL-CN";
         }

--- a/mssql.js
+++ b/mssql.js
@@ -3,6 +3,8 @@ module.exports = function(RED) {
 	var mustache = require('mustache');
 	var sql = require('mssql');
 
+
+
 	function connection(config) {
 	    RED.nodes.createNode(this, config);
 
@@ -10,22 +12,16 @@ module.exports = function(RED) {
 	    this.config = {
             user: node.credentials.username,
             password: node.credentials.password,
-						domain: node.credentials.domain,
+			domain: node.credentials.domain,
             server: config.server,
             database: config.database,
             options: {
-                           encrypt : config.encyption,
-                           useUTC: config.useUTC
-                       }
+               encrypt : config.encryption,
+               useUTC: config.useUTC
+           }
         };
 
-
-	    this.connection = sql;
-			/*
-			node.on('close',function(){
-   			node.pool.close(function(){});
-   		})
-			*/
+	    this.connection = sql;	
 		}
 
   	RED.nodes.registerType('MSSQL-CN', connection, {


### PR DESCRIPTION
This implements some functionality that allows the user to specify whether they want times to be read as though they are in UTC, or not. It modifies a configuration flag which when the MSSQL connection is created, using the [Node MSSQL](https://github.com/tediousjs/node-mssql) package.

When 'Assume UTC' is check-marked, dates are assumed to be in UTC as they arrive from the MSSQL connection. When it is not, the dates are assumed to be in local time which is then converted back into UTC.

To agree with behaviour prior to this pull request, the default behaviour is that 'Assume UTC' is set to true.

